### PR TITLE
Fix external verification resulting error

### DIFF
--- a/src/app/(base-layout)/settings/profile/_components/Profile.tsx
+++ b/src/app/(base-layout)/settings/profile/_components/Profile.tsx
@@ -71,9 +71,10 @@ export default function ProfileSettingsComponent({
         if (!initialVerificationCodeSent) setInitialVerificationCodeSent(true);
         if (!isVerificationCodeSent) {
             const generateCode = await generateVerificationCode();
-            if (generateCode) {
+            if (generateCode?.code || generateCode?.userId) {
                 const params = new URLSearchParams({
-                    code: generateCode,
+                    code: generateCode?.code,
+                    userId: generateCode?.userId,
                 });
                 const response = await fetch(
                     `/api/email/send/verification?${params}`,

--- a/src/app/(base-layout)/verify/email/[code]/[userId]/page.tsx
+++ b/src/app/(base-layout)/verify/email/[code]/[userId]/page.tsx
@@ -4,11 +4,11 @@ import { notFound } from "next/navigation";
 export default async function EmailVeritification({
     params,
 }: {
-    params: { code: string };
+    params: { code: string; userId: string };
 }) {
-    const { code } = params;
-    if (!code) notFound();
-    const verify = await verifyEmail(code);
+    const { code, userId } = params;
+    if (!code || !userId) notFound();
+    const verify = await verifyEmail(code, userId);
 
     return (
         <div className="mt-12 mb-12 mr-4 ml-4 lg:mr-28 lg:ml-28 mx-auto space-y-4">

--- a/src/app/api/email/send/verification/route.ts
+++ b/src/app/api/email/send/verification/route.ts
@@ -1,7 +1,5 @@
 import VerifyEmailTemplate from "@/components/email/templates/verification";
 import prisma from "@/db";
-import { authConfig } from "@/utils/authConfig";
-import { getServerSession } from "next-auth";
 import { NextRequest, NextResponse } from "next/server";
 import { Resend } from "resend";
 
@@ -12,11 +10,12 @@ export async function POST(req: NextRequest) {
         const url = new URL(req.url);
         const baseUrl = url.origin;
         const code = url.searchParams.get("code");
-        const verificationUrl = `${baseUrl}/verify/email/${code}`;
-        const session = await getServerSession(authConfig);
+        const userId = url.searchParams.get("userId");
+        const verificationUrl = `${baseUrl}/verify/email/${code}/${userId}`;
+        if (!userId) throw new Error("No user id provided");
         const user = await prisma.user.findUnique({
             where: {
-                id: session?.user?.id,
+                id: userId,
             },
         });
         if (user?.email) {

--- a/src/components/email/templates/verification.tsx
+++ b/src/components/email/templates/verification.tsx
@@ -55,7 +55,7 @@ export const VerifyEmailTemplate = ({
                         target="_blank"
                         style={{ ...link, color: "#898989" }}
                     >
-                        ZeFer
+                        ZeFer{" "}
                     </Link>
                     Tell your story to the world.
                     <br />

--- a/src/utils/actions/verification.ts
+++ b/src/utils/actions/verification.ts
@@ -33,29 +33,32 @@ export const generateVerificationCode = async () => {
             key: createKey(),
         },
     });
-    if (code) return code.key;
+    if (code)
+        return {
+            code: code.key,
+            userId: session?.user.id,
+        };
     return null;
 };
 
-export const verifyEmail = async (code: string) => {
-    const session = await getServerSession(authConfig);
+export const verifyEmail = async (code: string, userId: string) => {
     const verify = await prisma.emailVerificationCode.findUnique({
         where: {
             key: code,
-            userId: session?.user.id,
+            userId: userId,
         },
     });
     if (verify) {
         await prisma.user.update({
             where: {
-                id: session?.user.id,
+                id: userId,
             },
             data: {
                 emailVerified: new Date(),
             },
         });
         await prisma.emailVerificationCode.delete({
-            where: { userId: session?.user.id },
+            where: { userId: userId },
         });
         return true;
     }


### PR DESCRIPTION
When verifying on other devices not on a device user is currently logged in, it will result an error as it checks their session. Verification will now also send a userId on the link, it will be /verify/email/code/userId.