### PR TITLE
Redesign login page with daisyUI

### DIFF
--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -2,14 +2,19 @@
 
 import { getProviders, signIn } from "next-auth/react";
 import { useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useState, Suspense } from "react";
 import Image from "next/image";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEnvelope } from "@fortawesome/free-solid-svg-icons";
 import { faGithub, faGoogle } from "@fortawesome/free-brands-svg-icons";
+import type { ClientSafeProvider, LiteralUnion } from "next-auth/react";
+import type { BuiltInProviderType } from "next-auth/providers/index";
 
-export default function SignIn() {
-    const [providers, setProviders] = useState<any>(null);
+function SignInContent() {
+    const [providers, setProviders] = useState<Record<
+        LiteralUnion<BuiltInProviderType>,
+        ClientSafeProvider
+    > | null>(null);
     const [email, setEmail] = useState("");
     const searchParams = useSearchParams();
     const callbackUrl = searchParams.get("callbackUrl") || "/";
@@ -149,5 +154,19 @@ export default function SignIn() {
                 </div>
             </div>
         </div>
+    );
+}
+
+export default function SignIn() {
+    return (
+        <Suspense
+            fallback={
+                <div className="min-h-screen flex items-center justify-center bg-base-200">
+                    <div className="loading loading-spinner loading-lg"></div>
+                </div>
+            }
+        >
+            <SignInContent />
+        </Suspense>
     );
 }

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -4,6 +4,7 @@ import { getProviders, signIn } from "next-auth/react";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useState, Suspense } from "react";
 import Image from "next/image";
+import Link from "next/link";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEnvelope } from "@fortawesome/free-solid-svg-icons";
 import { faGithub, faGoogle } from "@fortawesome/free-brands-svg-icons";
@@ -142,13 +143,13 @@ function SignInContent() {
                     <div className="text-center mt-6">
                         <p className="text-sm text-base-content/60">
                             By signing in, you agree to our{" "}
-                            <a href="/terms" className="link link-primary">
+                            <Link href="/terms" className="link link-primary">
                                 Terms
-                            </a>{" "}
+                            </Link>{" "}
                             and{" "}
-                            <a href="/privacy" className="link link-primary">
+                            <Link href="/privacy" className="link link-primary">
                                 Privacy Policy
-                            </a>
+                            </Link>
                         </p>
                     </div>
                 </div>

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { getProviders, signIn } from "next-auth/react";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEnvelope } from "@fortawesome/free-solid-svg-icons";
+import { faGithub, faGoogle } from "@fortawesome/free-brands-svg-icons";
+
+export default function SignIn() {
+    const [providers, setProviders] = useState<any>(null);
+    const [email, setEmail] = useState("");
+    const searchParams = useSearchParams();
+    const callbackUrl = searchParams.get("callbackUrl") || "/";
+
+    useEffect(() => {
+        const fetchProviders = async () => {
+            const res = await getProviders();
+            setProviders(res);
+        };
+        fetchProviders();
+    }, []);
+
+    const handleEmailSignIn = (e: React.FormEvent) => {
+        e.preventDefault();
+        signIn("email", { email, callbackUrl });
+    };
+
+    const getProviderIcon = (providerId: string) => {
+        switch (providerId) {
+            case "google":
+                return faGoogle;
+            case "github":
+                return faGithub;
+            default:
+                return faEnvelope;
+        }
+    };
+
+    const getProviderStyle = (providerId: string) => {
+        switch (providerId) {
+            case "google":
+                return "btn-error";
+            case "github":
+                return "btn-neutral";
+            default:
+                return "btn-primary";
+        }
+    };
+
+    return (
+        <div className="min-h-screen flex items-center justify-center bg-base-200">
+            <div className="card w-full max-w-md bg-base-100 shadow-xl">
+                <div className="card-body">
+                    {/* Logo */}
+                    <div className="flex justify-center mb-6">
+                        <Image
+                            src="/zefer-text-with-logo.svg"
+                            alt="ZeFer Logo"
+                            width={180}
+                            height={60}
+                            priority
+                        />
+                    </div>
+
+                    {/* Title */}
+                    <h1 className="text-2xl font-bold text-center mb-2">
+                        Welcome Back
+                    </h1>
+                    <p className="text-center text-base-content/60 mb-6">
+                        Sign in to continue to ZeFer
+                    </p>
+
+                    {/* Email Sign In Form */}
+                    {providers?.email && (
+                        <form onSubmit={handleEmailSignIn} className="mb-4">
+                            <div className="form-control">
+                                <label className="label">
+                                    <span className="label-text">Email</span>
+                                </label>
+                                <input
+                                    type="email"
+                                    placeholder="your@email.com"
+                                    className="input input-bordered"
+                                    value={email}
+                                    onChange={(e) => setEmail(e.target.value)}
+                                    required
+                                />
+                            </div>
+                            <button
+                                type="submit"
+                                className="btn btn-primary w-full mt-4"
+                            >
+                                <FontAwesomeIcon icon={faEnvelope} />
+                                Sign in with Email
+                            </button>
+                        </form>
+                    )}
+
+                    {/* Divider */}
+                    {providers?.google || providers?.github ? (
+                        <div className="divider">OR</div>
+                    ) : null}
+
+                    {/* OAuth Providers */}
+                    <div className="space-y-3">
+                        {providers?.google && (
+                            <button
+                                onClick={() =>
+                                    signIn("google", { callbackUrl })
+                                }
+                                className={`btn ${getProviderStyle("google")} w-full`}
+                            >
+                                <FontAwesomeIcon
+                                    icon={getProviderIcon("google")}
+                                />
+                                Continue with Google
+                            </button>
+                        )}
+                        {providers?.github && (
+                            <button
+                                onClick={() =>
+                                    signIn("github", { callbackUrl })
+                                }
+                                className={`btn ${getProviderStyle("github")} w-full`}
+                            >
+                                <FontAwesomeIcon
+                                    icon={getProviderIcon("github")}
+                                />
+                                Continue with GitHub
+                            </button>
+                        )}
+                    </div>
+
+                    {/* Footer */}
+                    <div className="text-center mt-6">
+                        <p className="text-sm text-base-content/60">
+                            By signing in, you agree to our{" "}
+                            <a href="/terms" className="link link-primary">
+                                Terms
+                            </a>{" "}
+                            and{" "}
+                            <a href="/privacy" className="link link-primary">
+                                Privacy Policy
+                            </a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/utils/authConfig.ts
+++ b/src/utils/authConfig.ts
@@ -69,6 +69,7 @@ export const authConfig: AuthOptions = {
         logo: "/zefer.svg",
     },
     pages: {
+        signIn: "/auth/signin",
         newUser: "/settings/profile",
     },
 };


### PR DESCRIPTION
Redesign the login page to be more simple and modern using daisyUI components.

---
<a href="https://cursor.com/background-agent?bcId=bc-748ffe4c-a29c-4bdc-8d8b-1428787b7f36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-748ffe4c-a29c-4bdc-8d8b-1428787b7f36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new styled sign-in page with email, Google, and GitHub options and configures NextAuth to use it.
> 
> - **Auth UI**:
>   - New custom sign-in page at `src/app/auth/signin/page.tsx` using daisyUI.
>   - Supports `email` sign-in plus OAuth (`google`, `github`) via `next-auth` providers, with provider-specific styling and icons.
>   - Handles `callbackUrl` via `useSearchParams`; includes Suspense fallback loader, logo, and footer links to `Terms` and `Privacy Policy`.
> - **Auth Config**:
>   - Sets `pages.signIn` to `/auth/signin` in `src/utils/authConfig.ts` to route NextAuth to the new page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44b80fe68c6a1415328572044e9c4721c2545b9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->