### PR TITLE
fix(auth): resolve strict-null TS errors after Auth.js v5 migration

### DIFF
--- a/src/app/(base-layout)/[userId]/[slug]/_components/CommentBox.tsx
+++ b/src/app/(base-layout)/[userId]/[slug]/_components/CommentBox.tsx
@@ -84,11 +84,13 @@ export default function CommentBox({
     }, [editor?.commands, socket, titleId]);
 
     function submitComment() {
+        if (!session) return;
+
         if (editor?.getText() && !editor.isEmpty) {
             const content = editor.getJSON();
             const comment = {
                 titleId: titleId,
-                userId: session?.user.id,
+                userId: session.user.id,
                 content: JSON.stringify(content),
                 commentReplyPostId: commentReplyPostId,
             };
@@ -96,9 +98,9 @@ export default function CommentBox({
                 const commentReplyNotification: UserNotificationInputValidation =
                     {
                         userId: commentReplyUserId,
-                        fromUserId: session?.user.id,
-                        from: session?.user.name,
-                        fromImage: session?.user.image,
+                        fromUserId: session.user.id,
+                        from: session.user.name,
+                        fromImage: session.user.image,
                         message: `has replied to your comment on ${commentReplyPostTitle}`,
                         actionUrl: pathname,
                     };
@@ -107,9 +109,9 @@ export default function CommentBox({
             if (authorId && title) {
                 const commentNotification: UserNotificationInputValidation = {
                     userId: authorId,
-                    fromUserId: session?.user.id,
-                    from: session?.user.name,
-                    fromImage: session?.user.image,
+                    fromUserId: session.user.id,
+                    from: session.user.name,
+                    fromImage: session.user.image,
                     message: `has commented on your post`,
                     postId,
                     actionUrl: pathname,
@@ -128,13 +130,20 @@ export default function CommentBox({
                     <div className="flex gap-2 items-start">
                         <div className="avatar">
                             <div className="rounded-full prose-img:w-full !overflow-visible">
-                                <Image
-                                    src={session.user.image}
-                                    alt={session.user.name}
-                                    className="rounded-full"
-                                    width={40}
-                                    height={40}
-                                />
+                                {session.user.image ? (
+                                    <Image
+                                        src={session.user.image}
+                                        alt={session.user.name ?? "Profile image"}
+                                        className="rounded-full"
+                                        width={40}
+                                        height={40}
+                                    />
+                                ) : (
+                                    <div
+                                        className="w-10 h-10 rounded-full bg-base-300"
+                                        aria-hidden
+                                    />
+                                )}
                             </div>
                         </div>
                         <div className="container">

--- a/src/app/(base-layout)/[userId]/[slug]/_components/CommentContainer.tsx
+++ b/src/app/(base-layout)/[userId]/[slug]/_components/CommentContainer.tsx
@@ -69,8 +69,10 @@ export default function CommentContainer({
             refetch();
         });
         const getOwnerComment = async () => {
+            if (!session) return;
+
             const { commentOwner, postOwner } = await isCommentOwner(
-                session?.user.id,
+                session.user.id,
                 titleId,
             );
             setOwnComment(commentOwner);

--- a/src/app/(base-layout)/manage/organization/page.tsx
+++ b/src/app/(base-layout)/manage/organization/page.tsx
@@ -1,27 +1,30 @@
 import prisma from "@/db";
 import { auth } from "@/auth";
+import { redirect } from "next/navigation";
 
 import OrganizationManageContainer from "./_components/OrganizationManageContainer";
 
 export default async function ManageOrganizations() {
     const session = await auth();
+    if (!session) redirect("/api/auth/signin");
+
     const organizations = await prisma.organization.findMany({
         where: {
             OR: [
                 {
-                    ownerId: session?.user.id,
+                    ownerId: session.user.id,
                 },
                 {
                     admins: {
                         some: {
-                            id: session?.user.id,
+                            id: session.user.id,
                         },
                     },
                 },
                 {
                     members: {
                         some: {
-                            id: session?.user.id,
+                            id: session.user.id,
                         },
                     },
                 },
@@ -41,7 +44,7 @@ export default async function ManageOrganizations() {
             <div className="mx-auto lg:w-9/12 justify-center space-y-6">
                 <OrganizationManageContainer
                     organizations={organizations}
-                    sessionUserId={session?.user.id}
+                    sessionUserId={session.user.id}
                 />
             </div>
         </div>

--- a/src/app/(base-layout)/settings/profile/_components/Profile.tsx
+++ b/src/app/(base-layout)/settings/profile/_components/Profile.tsx
@@ -71,10 +71,10 @@ export default function ProfileSettingsComponent({
         if (!initialVerificationCodeSent) setInitialVerificationCodeSent(true);
         if (!isVerificationCodeSent) {
             const generateCode = await generateVerificationCode();
-            if (generateCode?.code || generateCode?.userId) {
+            if (generateCode) {
                 const params = new URLSearchParams({
-                    code: generateCode?.code,
-                    userId: generateCode?.userId,
+                    code: generateCode.code,
+                    userId: generateCode.userId,
                 });
                 const response = await fetch(
                     `/api/email/send/verification?${params}`,

--- a/src/app/api/post/manage/route.ts
+++ b/src/app/api/post/manage/route.ts
@@ -15,6 +15,10 @@ export async function GET(req: NextRequest): Promise<any> {
         | "most-comments";
 
     const session = await auth();
+    if (!session) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
     interface PrismaQuery {
         where: {
             userId: string;
@@ -25,7 +29,7 @@ export async function GET(req: NextRequest): Promise<any> {
 
     const prismaQuery: PrismaQuery = {
         where: {
-            userId: session?.user.id,
+            userId: session.user.id,
         },
         orderBy: {
             createdAt: "desc", // default sorting is it's recent creation
@@ -84,6 +88,11 @@ export async function GET(req: NextRequest): Promise<any> {
 }
 
 export async function PUT(req: NextRequest): Promise<any> {
+    const session = await auth();
+    if (!session) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
     const url = new URL(req.url);
     const postId = url.searchParams.get("postId") as string;
     const publish = url.searchParams.get("publish") as "true" | "false";
@@ -103,6 +112,11 @@ export async function PUT(req: NextRequest): Promise<any> {
 }
 
 export async function DELETE(req: NextRequest): Promise<any> {
+    const session = await auth();
+    if (!session) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
     const url = new URL(req.url);
 
     const postId = url.searchParams.get("postId") as string;

--- a/src/app/api/post/manage/series/post/route.ts
+++ b/src/app/api/post/manage/series/post/route.ts
@@ -14,6 +14,7 @@ type PrismaWhereQuery = {
 
 export async function GET(req: NextRequest): Promise<any> {
     const session = await auth()
+    if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     const url = new URL(req.url)
     const action = url.searchParams.get('action') as 'add' | 'remove'
     const seriesId = url.searchParams.get('seriesId') as string
@@ -21,7 +22,7 @@ export async function GET(req: NextRequest): Promise<any> {
 
     let prismaWhereQuery: PrismaWhereQuery = {
         where: {
-            userId: session?.user.id,
+            userId: session.user.id,
             NOT: {
                 series: {
                     some: {
@@ -35,7 +36,7 @@ export async function GET(req: NextRequest): Promise<any> {
 
     if (action === 'remove') {
         prismaWhereQuery.where = {
-            userId: session?.user.id,
+            userId: session.user.id,
             series: {
                 some: {
                     id: seriesId,
@@ -60,6 +61,7 @@ export async function GET(req: NextRequest): Promise<any> {
 
 export async function POST(req: NextRequest): Promise<any> {
     const session = await auth()
+    if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     const url = new URL(req.url)
     const seriesId = url.searchParams.get('seriesId') as string
     const postId = url.searchParams.get('postId') as string
@@ -68,7 +70,7 @@ export async function POST(req: NextRequest): Promise<any> {
         const addPostToSeries = await prisma.postSeries.update({
             where: {
                 id: seriesId,
-                authorId: session?.user.id
+                authorId: session.user.id
             },
             data: {
                 posts: {
@@ -86,6 +88,7 @@ export async function POST(req: NextRequest): Promise<any> {
 
 export async function DELETE(req: NextRequest): Promise<any> {
     const session = await auth()
+    if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     const url = new URL(req.url)
     const seriesId = url.searchParams.get('seriesId') as string
     const postId = url.searchParams.get('postId') as string
@@ -93,7 +96,7 @@ export async function DELETE(req: NextRequest): Promise<any> {
     try {
         const disconnectPostToSeries = await prisma.postSeries.update({
             where: {
-                authorId: session?.user.id,
+                authorId: session.user.id,
                 id: seriesId
             },
             data: {

--- a/src/app/api/user/cloudinary/route.ts
+++ b/src/app/api/user/cloudinary/route.ts
@@ -8,13 +8,16 @@ export async function POST(req: Request): Promise<any> {
     const body = await req.formData();
     const img = body.get("imgFile");
     const session = await auth();
+    if (!session) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
 
     try {
         if (!img) throw new Error("No image file found");
         const cloudinary = await uploadCloudinary({
             file: img,
             folder: "user",
-            public_id: session?.user.id,
+            public_id: session.user.id,
         });
         if (cloudinary.upload.ok) {
             const image = getCloudinaryImage({
@@ -23,7 +26,7 @@ export async function POST(req: Request): Promise<any> {
                 folder: cloudinary.metadata.folder,
             });
             const updateImage = await prisma.user.update({
-                where: { id: session?.user.id },
+                where: { id: session.user.id },
                 data: {
                     image,
                 },

--- a/src/components/reactions/actions/CommentReactionButton.tsx
+++ b/src/components/reactions/actions/CommentReactionButton.tsx
@@ -47,6 +47,8 @@ export default function CommentReactionButton({
     }, [id, isLoggedIn]);
 
     async function updateCommentReaction() {
+        if (!session) return;
+
         if (typeof commentReaction !== "undefined") {
             const removeCommentReaction = await deleteCommentReaction(id);
             if (removeCommentReaction) {
@@ -64,9 +66,9 @@ export default function CommentReactionButton({
                 const reactionNotification: UserNotificationInputValidation = {
                     userId: userId,
                     postId: id,
-                    fromUserId: session?.user.id,
-                    from: session?.user.name,
-                    fromImage: session?.user.image,
+                    fromUserId: session.user.id,
+                    from: session.user.name,
+                    fromImage: session.user.image,
                     message: `has reacted with ❤️ to your comment on your post`,
                     actionUrl: pathname,
                 };

--- a/src/components/reactions/actions/PostReactionButton.tsx
+++ b/src/components/reactions/actions/PostReactionButton.tsx
@@ -45,6 +45,8 @@ export default function PostReactionButton({
     }, [id, session]);
 
     async function updatePostReaction() {
+        if (!session) return;
+
         if (typeof postReaction !== "undefined") {
             const removePostReaction = await deletePostReaction(id);
             if (removePostReaction) {
@@ -61,9 +63,9 @@ export default function PostReactionButton({
                 setPostReactionCount((prev) => prev + 1);
                 const reactionNotification: UserNotificationInputValidation = {
                     userId: authorId,
-                    fromUserId: session?.user.id,
-                    from: session?.user.name,
-                    fromImage: session?.user.image,
+                    fromUserId: session.user.id,
+                    from: session.user.name,
+                    fromImage: session.user.image,
                     message: `has reacted with ❤️ to your post`,
                     postId: id,
                     actionUrl: pathname,

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,8 +1,8 @@
 type UserNotificationInputValidation = {
     userId: string;
     fromUserId: string;
-    from: string;
-    fromImage: string;
+    from?: string | null;
+    fromImage?: string | null;
     message: string;
     postId?: string;
     actionUrl: string;

--- a/src/utils/actions/reactions.ts
+++ b/src/utils/actions/reactions.ts
@@ -6,12 +6,13 @@ import { TCommentReaction, TPostReaction } from "@/types/reaction"
 
 export async function getUserInitialPostReaction(postId: string) {
     const session = await auth()
+    if (!session) throw new Error("Unauthorized")
 
     const checkPostReaction = await prisma.postReaction.findUnique({
         where: {
             postId_userId: {
                 postId: postId,
-                userId: session?.user.id
+                userId: session.user.id
             }
         }
     })
@@ -21,12 +22,13 @@ export async function getUserInitialPostReaction(postId: string) {
 
 export async function updateCreatePostReaction(postId: string, type: TPostReaction) {
     const session = await auth()
+    if (!session) throw new Error("Unauthorized")
 
     try {
         const addPostReaction = await prisma.postReaction.upsert({
             where: {
                 postId_userId: {
-                    userId: session?.user.id,
+                    userId: session.user.id,
                     postId: postId
                 }
             },
@@ -42,7 +44,7 @@ export async function updateCreatePostReaction(postId: string, type: TPostReacti
                 },
                 user: {
                     connect: {
-                        id: session?.user.id
+                        id: session.user.id
                     }
                 }
             }
@@ -55,13 +57,14 @@ export async function updateCreatePostReaction(postId: string, type: TPostReacti
 
 export async function deletePostReaction(postId: string) {
     const session = await auth()
+    if (!session) throw new Error("Unauthorized")
 
     try {
         const deletePostReaction = await prisma.postReaction.delete({
             where: {
                 postId_userId: {
                     postId: postId,
-                    userId: session?.user.id
+                    userId: session.user.id
                 }
             }
         })
@@ -73,12 +76,13 @@ export async function deletePostReaction(postId: string) {
 
 export async function getInitialCommentReaction(commentId: string) {
     const session = await auth()
+    if (!session) throw new Error("Unauthorized")
 
     const checkCommentReaction = await prisma.commentReaction.findUnique({
         where: {
             commentId_userId: {
                 commentId: commentId,
-                userId: session?.user.id
+                userId: session.user.id
             }
         }
     })
@@ -89,13 +93,14 @@ export async function getInitialCommentReaction(commentId: string) {
 
 export async function updateCreateCommentReaction(commentId: string, type: TCommentReaction) {
     const session = await auth()
+    if (!session) throw new Error("Unauthorized")
 
     try {
         const addCommentReaction = await prisma.commentReaction.upsert({
             where: {
                 commentId_userId: {
                     commentId: commentId,
-                    userId: session?.user.id
+                    userId: session.user.id
                 },
             },
             update: {
@@ -110,7 +115,7 @@ export async function updateCreateCommentReaction(commentId: string, type: TComm
                 },
                 user: {
                     connect: {
-                        id: session?.user.id
+                        id: session.user.id
                     }
                 }
             }
@@ -123,13 +128,14 @@ export async function updateCreateCommentReaction(commentId: string, type: TComm
 
 export async function deleteCommentReaction(commentId: string) {
     const session = await auth()
+    if (!session) throw new Error("Unauthorized")
 
     try {
         const deleteCommentReaction = await prisma.commentReaction.delete({
             where: {
                 commentId_userId: {
                     commentId: commentId,
-                    userId: session?.user.id
+                    userId: session.user.id
                 }
             }
         })

--- a/src/utils/actions/verification.ts
+++ b/src/utils/actions/verification.ts
@@ -5,14 +5,16 @@ import { auth } from "@/auth";
 import { init } from "@paralleldrive/cuid2";
 
 export const generateVerificationCode = async () => {
+    const session = await auth();
+    if (!session) throw new Error("Unauthorized");
+
     const createKey = init({
         length: 48,
     });
-    const session = await auth();
     const existingVerificationCode =
         await prisma.emailVerificationCode.findUnique({
             where: {
-                userId: session?.user.id,
+                userId: session.user.id,
             },
         });
     if (existingVerificationCode) {
@@ -26,7 +28,7 @@ export const generateVerificationCode = async () => {
         data: {
             user: {
                 connect: {
-                    id: session?.user.id,
+                    id: session.user.id,
                 },
             },
             key: createKey(),
@@ -35,7 +37,7 @@ export const generateVerificationCode = async () => {
     if (code)
         return {
             code: code.key,
-            userId: session?.user.id,
+            userId: session.user.id,
         };
     return null;
 };
@@ -66,6 +68,8 @@ export const verifyEmail = async (code: string, userId: string) => {
 
 export const getCurrentEmailVerificationCodeDate = async () => {
     const session = await auth();
+    if (!session) return null;
+
     const code = await prisma.emailVerificationCode.findUnique({
         where: {
             userId: session?.user.id,


### PR DESCRIPTION
The Auth.js v5 migration left session field accesses unguarded, so `npm run build` failed type-check with 27 `TS2322`/`TS2345` errors once `strict: true` saw nullable `session.user.id`, `.name`, and `.image`. No non-null assertions or fabricated defaults were introduced.

### What this PR does

Adds explicit unauthenticated guards at every trust boundary touched by the v5 migration:

- **Server Actions** — `src/utils/actions/reactions.ts` (6 fns), `src/utils/actions/verification.ts` (`generateVerificationCode` now rejects anonymous callers; `getCurrentEmailVerificationCodeDate` returns `null` for anonymous callers to match its existing null-record shape).
- **Route Handlers** — `src/app/api/post/manage/route.ts` (`GET`, `PUT`, `DELETE`), `src/app/api/post/manage/series/post/route.ts` (`GET`, `POST`, `DELETE`), `src/app/api/user/cloudinary/route.ts` all return 401 JSON when there is no session.
- **Server Component** — `src/app/(base-layout)/manage/organization/page.tsx` redirects to `/api/auth/signin`.
- **Client event handlers** — `CommentBox.submitComment`, `CommentContainer.getOwnerComment`, `PostReactionButton.updatePostReaction`, `CommentReactionButton.updateCommentReaction` early-return when there is no session. The `CommentBox` avatar element now falls back to a neutral placeholder when the avatar URL is missing, instead of hiding the whole editor.
- **Notification type** — `src/types/notification.ts` marks `from` and `fromImage` optional, matching the nullable Prisma `UserNotifications` schema.
- **Profile form** — `src/app/(base-layout)/settings/profile/_components/Profile.tsx` only fires the verification request when both `code` and `userId` are present.

### Verification

- `npx tsc --noEmit --pretty false` exits 0 (was 27 errors).
- `npm run build` exits 0; the route table includes `/sitemap.xml` and the `Proxy (Middleware)`.
- Defense-in-depth only: `src/proxy.ts` still protects these paths at the matcher level; the per-handler guards do not replace it.

### Files

12 files changed, +97 / -49.

### Follow-ups (not in this PR)

- Extract the recurring `if (!session) return NextResponse.json({error: "Unauthorized"}, {status: 401})` block across route handlers and the matching redirect in server components into a `requireSession()` helper in `src/auth.ts`.
- Add a Playwright regression for `CommentBox`: an authenticated user with no avatar should still see the editor.
- The 22 pre-existing `react-hooks/*` lint errors across `Tiptap.tsx`, `MenuBar.tsx`, etc., are not introduced by this diff and remain tracked separately.