### PR TITLE
fix(comments): add session to CommentContainer useEffect deps

### DIFF
--- a/src/app/(base-layout)/[userId]/[slug]/_components/CommentContainer.tsx
+++ b/src/app/(base-layout)/[userId]/[slug]/_components/CommentContainer.tsx
@@ -83,7 +83,7 @@ export default function CommentContainer({
         return () => {
             socket.off("refetchReplies");
         };
-    }, [id, refetch, socket, session?.user.id, titleId]);
+    }, [id, refetch, socket, session, session?.user.id, titleId]);
 
     const deleteCommentBtn = async (id: string) => {
         const data = await deleteComments(id);


### PR DESCRIPTION
Resolves the last remaining react-hooks/exhaustive-deps warning in the repo (src/app/(base-layout)/[userId]/[slug]/_components/CommentContainer.tsx:86).

The effect already guards on !session inside the body and accesses session.user.id. Adding session (and the existing session?.user.id) to the dependency array is safe because useSession returns a referentially stable object between renders.

Verified: npm run lint --max-warnings 0 passes; npx tsc --noEmit is clean.

Note: the 26 pre-existing lint errors called out in docs/CONCERNS.md Group D were cleared by commit 177d91b (chore(lint): decompose Tiptap.tsx, clear 22 pre-existing lint errors, add vitest) before this PR. The only remaining issue was this single warning.